### PR TITLE
Convert selectors to use props, rename away from `make__`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ const accountDataReducer = (state = {}, action) => {
 
 ### Selecting:
 
-This library also provides helpers getting information about ongoing actions: `makeIsPendingSelector` and `makeErrorSelector`. These two functions let you make selectors for pending and error states from your actions:
+This library also provides helpers getting information about ongoing actions: `isPendingSelector` and `errorSelector`. These two functions let you make selectors for pending and error states from your actions:
 
 ```js
-const selectAccountsFetchPending = makeIsPendingSelector(FETCH_ACCOUNTS);
+const selectAccountsFetchPending = isPendingSelector(FETCH_ACCOUNTS);
 
 selectAccountsPending(state);
 ```
 
 ```js
-const selectAccountsFetchFailed = makeErrorSelector(FETCH_ACCOUNTS);
+const selectAccountsFetchFailed = errorSelector(FETCH_ACCOUNTS);
 
 // If an error happened, this will give you an object containing the error's
 // name, message, and stack trace.
@@ -160,21 +160,21 @@ const accountDataReducer = (state = {}, action) => {
 Finally, the identifier can also be used in your selectors to get info about specific requests:
 
 ```js
-import { makeIsPendingSelector } from '@wealthsimple/async-action';
+import { isPendingSelector } from '@wealthsimple/async-action';
 
-const selector = makeIsPendingSelector('FETCH_ACCOUNT_DATA', 'id1');
+const selector = isPendingSelector('FETCH_ACCOUNT_DATA', 'id1');
 
 // Returns true if the FETCH_ACCOUNT_DATA request with identifier === 'id1'
 // is pending.
 selector(state);
 ```
 
-Or if you only care whether any instance of this request is pending you can use `makeAllPendingSelector`:
+Or if you only care whether any instance of this request is pending you can use `allPendingSelector`:
 
 ```js
-import { makeAllPendingSelector } from '@wealthsimple/async-action';
+import { allPendingSelector } from '@wealthsimple/async-action';
 
-const selector = makeAllPendingSelector('FETCH_ACCOUNT_DATA');
+const selector = allPendingSelector('FETCH_ACCOUNT_DATA');
 
 // Returns an array of identifiers for this action type that are
 // currently pending.

--- a/src/async.action.js
+++ b/src/async.action.js
@@ -7,10 +7,7 @@ import type {
   SimpleAction,
   GetState,
 } from './async.types';
-import {
-  makeIsPendingSelector,
-  makeCachedResponseSelector,
-} from './async.selectors';
+import { isPendingSelector, cachedResponseSelector } from './async.selectors';
 
 export const isPending = (action: $Subtype<SimpleAction>) =>
   !!action.meta && action.meta.status === 'ASYNC_PENDING';
@@ -45,8 +42,7 @@ export const createAsyncAction = <Action: SimpleAction, Payload>(
   dispatch: Dispatch<AsyncAction<Action, Payload>>,
   getState: GetState<*>,
 ): Promise<Payload> => {
-  const isPendingSelector = makeIsPendingSelector(action.type, identifier);
-  if (isPendingSelector(getState())) {
+  if (isPendingSelector(getState(), { type: action.type, identifier })) {
     dispatch({
       ...action,
       payload: null,
@@ -57,14 +53,14 @@ export const createAsyncAction = <Action: SimpleAction, Payload>(
   }
 
   if (cache && !overwriteCache) {
-    const cachedResponseSelector = makeCachedResponseSelector(
-      action.type,
+    // $FlowFixMe
+    const cachedResponse: Payload = cachedResponseSelector(getState(), {
+      type: action.type,
       identifier,
       ttlSeconds,
-    );
+    });
 
-    const cachedResponse = cachedResponseSelector(getState());
-    if (cachedResponse) {
+    if (cachedResponse !== null && undefined !== cachedResponse) {
       dispatch({
         ...action,
         payload: cachedResponse,

--- a/src/async.selectors.test.js
+++ b/src/async.selectors.test.js
@@ -1,8 +1,8 @@
 // @flow
 import {
-  makeIsPendingSelector,
-  makeErrorSelector,
-  makeAllPendingSelector,
+  isPendingSelector,
+  errorSelector,
+  allPendingSelector,
 } from './async.selectors';
 
 describe('AsyncSelectors', () => {
@@ -30,33 +30,53 @@ describe('AsyncSelectors', () => {
   });
 
   it('should let you select an ongoing action', () => {
-    const fooId1PendingSelector = makeIsPendingSelector('FOO_ACTION', 'fooId1');
-    const fooId2PendingSelector = makeIsPendingSelector('FOO_ACTION', 'fooId2');
-    const fooId3PendingSelector = makeIsPendingSelector('FOO_ACTION', 'fooId3');
+    const fooId1Pending = isPendingSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId1',
+    });
+    const fooId2Pending = isPendingSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId2',
+    });
+    const fooId3Pending = isPendingSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId3',
+    });
 
-    expect(fooId1PendingSelector(state)).toBe(true);
-    expect(fooId2PendingSelector(state)).toBe(false);
-    expect(fooId3PendingSelector(state)).toBe(false);
+    expect(fooId1Pending).toBe(true);
+    expect(fooId2Pending).toBe(false);
+    expect(fooId3Pending).toBe(false);
   });
 
   it('should let you select an error', () => {
-    const fooId1ErrorSelector = makeErrorSelector('FOO_ACTION', 'fooId1');
-    const fooId2ErrorSelector = makeErrorSelector('FOO_ACTION', 'fooId2');
-    const fooId3ErrorSelector = makeErrorSelector('FOO_ACTION', 'fooId3');
+    const fooId1Error = errorSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId1',
+    });
+    const fooId2Error = errorSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId2',
+    });
+    const fooId3Error = errorSelector(state, {
+      type: 'FOO_ACTION',
+      identifier: 'fooId3',
+    });
 
-    expect(fooId1ErrorSelector(state)).toBe(null);
-    expect(fooId2ErrorSelector(state)).toEqual({
+    expect(fooId1Error).toBe(null);
+    expect(fooId2Error).toEqual({
       name: 'Error',
       message: 'BOOM',
       stack: fakeError.stack,
     });
 
-    expect(fooId3ErrorSelector(state)).toBe(null);
+    expect(fooId3Error).toBe(null);
   });
 
   it('should let you select all ongoing identifiers for an action', () => {
-    const fooActionAllPendingSelector = makeAllPendingSelector('FOO_ACTION');
+    const fooActionAllPending = allPendingSelector(state, {
+      type: 'FOO_ACTION',
+    });
 
-    expect(fooActionAllPendingSelector(state)).toEqual(['fooId0', 'fooId1']);
+    expect(fooActionAllPending).toEqual(['fooId0', 'fooId1']);
   });
 });

--- a/src/async.types.js
+++ b/src/async.types.js
@@ -47,9 +47,16 @@ export type AsyncActionRecord = {
 };
 
 export type AsyncActionState = {
-  [actionType: string]: AsyncActionRecord,
+  [type: string]: AsyncActionRecord,
 };
 
-export type AllPendingSelector = (state: *) => string[];
-export type IsPendingSelector = (state: *) => boolean;
-export type ErrorSelector = (state: *) => ?ErrorInfo;
+export type SelectorProps = {
+  type: string,
+  identifier?: string,
+  ttlSeconds?: number,
+};
+
+export type AllPendingSelector = (state: *, props: SelectorProps) => string[];
+export type IsPendingSelector = (state: *, props: SelectorProps) => boolean;
+export type ErrorSelector = (state: *, props: SelectorProps) => ?ErrorInfo;
+export type CachedResponseSelector = (state: *, props: SelectorProps) => mixed;

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@
 export * from './async.action';
 export * from './async.reducer';
 export {
-  makeIsPendingSelector,
-  makeErrorSelector,
-  makeAllPendingSelector,
+  isPendingSelector,
+  errorSelector,
+  allPendingSelector,
 } from './async.selectors';
 export * from './async.types';


### PR DESCRIPTION
The current structure of the `make__` selectors would return a new instance of the selector every time they were called, and not actually memoize the response.

This was initially stumbled upon in hemingway-mobile ([context](https://wealthsimple.slack.com/archives/CBXATSJA1/p1559765945045200)) when we realized that the code inside our selectors (that were structured like these `make___` selectors) was running *much more frequently* than we would have expected if it was properly memoized. 

After some research, we realized we could use the `props` [available with reselect](https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances) to prevent multiple new instances while still retaining the benefit of being able to pass in various values.

## Proposal

Instead of using the current `makeSelector(actionType, identifier)` structure that would THEN return a selector, use a `selector(state, { type, identifier })` structure to ensure the response is memoized.

## NOTE

This is a breaking change; would it be  worth keeping the original selectors around (and flagging them as Deprecated)?